### PR TITLE
pb: Add system_ext to dynamic partitions list

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -901,7 +901,7 @@ $(foreach group,$(call to-upper,$(BOARD_SUPER_PARTITION_GROUPS)), \
 )
 
 # BOARD_*_PARTITION_LIST: a list of the following tokens
-valid_super_partition_list := system vendor product product_services odm
+valid_super_partition_list := system system_ext vendor product product_services odm
 $(foreach group,$(call to-upper,$(BOARD_SUPER_PARTITION_GROUPS)), \
     $(if $(filter-out $(valid_super_partition_list),$(BOARD_$(group)_PARTITION_LIST)), \
         $(error BOARD_$(group)_PARTITION_LIST contains invalid partition name \


### PR DESCRIPTION
This commit, with a proper implementation in device tree fstabs like here https://github.com/Redmi-K30-5G/device_xiaomi_picasso_recovery/commit/0ca9a2deeccd84837c5f050deb8c9d4b950ef426 , allows PBRP to mount the new system_ext partition in Android 11 correctly!